### PR TITLE
Fix three code bugs

### DIFF
--- a/03-GettingStarted/01-first-server/README.md
+++ b/03-GettingStarted/01-first-server/README.md
@@ -58,14 +58,25 @@ server.registerTool({
   name: "calculator",
   description: "Performs basic calculations",
   parameters: {
-    expression: {
-      type: "string",
-      description: "The math expression to evaluate"
-    }
+    a: { type: "number", description: "First operand" },
+    b: { type: "number", description: "Second operand" },
+    op: { type: "string", enum: ["add", "subtract", "multiply", "divide"], description: "Operation" }
   },
-  handler: async (params) => {
-    const result = eval(params.expression);
-    return { result };
+  handler: async ({ a, b, op }) => {
+    if (op === "divide" && b === 0) {
+      throw new Error("Division by zero");
+    }
+    const operations = {
+      add: (x, y) => x + y,
+      subtract: (x, y) => x - y,
+      multiply: (x, y) => x * y,
+      divide: (x, y) => x / y
+    };
+    const fn = operations[op];
+    if (!fn) {
+      throw new Error("Unsupported operation");
+    }
+    return { result: fn(a, b) };
   }
 });
 

--- a/03-GettingStarted/02-client/README.md
+++ b/03-GettingStarted/02-client/README.md
@@ -513,7 +513,7 @@ To run the client, type the following command in the terminal:
 Add the following entry to your "scripts" section in *package.json*:
 
 ```json
-"client": "tsx && node build/client.js"
+"client": "tsc && node build/client.js"
 ```
 
 ```sh

--- a/05-AdvancedTopics/requirements.txt
+++ b/05-AdvancedTopics/requirements.txt
@@ -1,4 +1,4 @@
-httpx
-python-dotenv
-pydantic
-mcp
+httpx==0.27.0
+python-dotenv==1.0.1
+pydantic==2.7.4
+mcp==1.11.0


### PR DESCRIPTION
# Purpose

This PR addresses three issues to improve security, reliability, and functionality of the examples:

1.  **Insecure `eval` replacement**: Replaced an insecure `eval()` call in `03-GettingStarted/01-first-server/README.md` with a safer, explicit calculator API to prevent potential remote code execution. This changes the `calculator` tool's parameters from `expression` to `a`, `b`, and `op`.
2.  **Broken npm script fix**: Corrected a non-functional `npm` script in `03-GettingStarted/02-client/README.md` to `tsc && node build/client.js`, ensuring the TypeScript client example builds and runs correctly.
3.  **Dependency pinning**: Pinned Python dependencies in `05-AdvancedTopics/requirements.txt` to specific versions for improved reproducibility and reduced supply-chain risk.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

---
<a href="https://cursor.com/background-agent?bcId=bc-e95b49b0-fe9b-4f44-97bc-04c126cec4fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e95b49b0-fe9b-4f44-97bc-04c126cec4fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

